### PR TITLE
Fix service constructor arguments

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -90,48 +90,48 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(AlbumServiceInterface::class, AlbumService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(ArtistServiceInterface::class, ArtistService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(AuthServiceInterface::class, AuthService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
                 new Parameter('nucleos_lastfm.api.auth_url'),
             ])
 
         ->set(ChartServiceInterface::class, ChartService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(GeoServiceInterface::class, GeoService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(LibraryServiceInterface::class, LibraryService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(TagServiceInterface::class, TagService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(TrackServiceInterface::class, TrackService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ->set(UserServiceInterface::class, UserService::class)
             ->args([
-                new Reference(ConnectionInterface::class),
+                new Reference(ApiClientInterface::class),
             ])
 
         ;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

The service constructors expects a `ApiClientInterface`.
